### PR TITLE
Enable ".Which" extension for value-containing assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ var optionnone = Option<int>.None;
 option.Should().BeSome();
 option.Should().BeSome(8);
 option.Should().BeSome(s => s.Should().Be(8));
+option.Should().BeSome().Which.Should().Be(8);
 
 optionnone.Should().BeNone();
 ```
@@ -56,10 +57,12 @@ Either<int, string> right = Prelude.Right("a");
 
 left.Should().BeLeft();
 left.Should().BeLeft(l => l.Should().Be(8));
+left.Should().BeLeft().Which.Should().Be(8);
 left.Should().Be(8);
 
 right.Should().BeRight();
 right.Should().BeRight(r => r.Should().Be("a"));
+right.Should().BeRight().Which.Should().Be("a");
 right.Should().Be("a");
 ```
 

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtEitherAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtEitherAssertionsTest.cs
@@ -34,6 +34,22 @@ public class LanguageExtEitherAssertionsTest
     }
 
     [Fact]
+    public void BeLeft_with_expected_Left_using_which_returns_expected_result()
+    {
+        var action = () => LeftResult().Should().BeLeft().Which.Should().Be(8);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeLeft_with_unexpected_Left_using_which_returns_expected_result()
+    {
+        var action = () => LeftResult().Should().BeLeft().Which.Should().Be(4);
+
+        action.Should().Throw<XunitException>();
+    }
+
+    [Fact]
     public void BeLeft_with_Right_returns_expected_result()
     {
         var action = () => RightResult().Should().BeLeft();
@@ -61,6 +77,22 @@ public class LanguageExtEitherAssertionsTest
     public void BeRight_with_unexpected_Right_returns_expected_result()
     {
         var action = () => RightResult().Should().BeRight(p => p.Should().Be("z"));
+
+        action.Should().Throw<XunitException>();
+    }
+
+    [Fact]
+    public void BeRight_with_expected_Right_using_which_returns_expected_result()
+    {
+        var action = () => RightResult().Should().BeRight().Which.Should().Be("a");
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeRight_with_unexpected_Right_using_which_returns_expected_result()
+    {
+        var action = () => RightResult().Should().BeRight().Which.Should().Be("z");
 
         action.Should().Throw<XunitException>();
     }

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtEitherAsyncAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtEitherAsyncAssertionsTest.cs
@@ -18,6 +18,22 @@ public class LanguageExtEitherAsyncAssertionsTest
     }
 
     [Fact]
+    public void BeLeft_with_expected_LeftAsync_using_which_returns_expected_result()
+    {
+        var action = () => LeftResult().Should().BeLeft().Which.Should().Be(123);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeLeft_with_unexpected_LeftAsync_using_which_returns_expected_result()
+    {
+        var action = () => LeftResult().Should().BeLeft().Which.Should().Be(456);
+
+        action.Should().Throw<XunitException>();
+    }
+
+    [Fact]
     public void BeLeft_with_RightAsync_returns_expected_result()
     {
         var action = () => RightResult().Should().BeLeft();
@@ -39,6 +55,22 @@ public class LanguageExtEitherAsyncAssertionsTest
         var action = () => RightResult().Should().BeRight();
 
         action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeRight_with_expected_RightAsync_using_which_returns_expected_result()
+    {
+        var action = () => RightResult().Should().BeRight().Which.Should().Be("abc");
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeRight_with_unexpected_RightAsync_using_which_returns_expected_result()
+    {
+        var action = () => RightResult().Should().BeRight().Which.Should().Be("def");
+
+        action.Should().Throw<XunitException>();
     }
 
     [Fact]

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtEitherUnsafeAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtEitherUnsafeAssertionsTest.cs
@@ -26,6 +26,22 @@ public class LanguageExtEitherUnsafeAssertionsTest
     }
 
     [Fact]
+    public void BeLeft_with_expected_Left_using_which_returns_expected_result()
+    {
+        var action = () => LeftResult().Should().BeLeft().Which.Should().Be(123);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeLeft_with_unexpected_Left_using_which_returns_expected_result()
+    {
+        var action = () => LeftResult().Should().BeLeft().Which.Should().Be(456);
+
+        action.Should().Throw<XunitException>();
+    }
+
+    [Fact]
     public void BeRight_with_LeftUnsafe_returns_expected_result()
     {
         var action = () => LeftResult().Should().BeRight();
@@ -39,6 +55,22 @@ public class LanguageExtEitherUnsafeAssertionsTest
         var action = () => RightResult().Should().BeRight();
 
         action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeRight_with_expected_Right_using_which_returns_expected_result()
+    {
+        var action = () => RightResult().Should().BeRight().Which.Should().Be("abc");
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeRight_with_unexpected_Right_using_which_returns_expected_result()
+    {
+        var action = () => RightResult().Should().BeRight().Which.Should().Be("def");
+
+        action.Should().Throw<XunitException>();
     }
 
     [Fact]

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtMonoidValidationAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtMonoidValidationAssertionsTest.cs
@@ -1,0 +1,77 @@
+﻿using LanguageExt.ClassInstances;
+using LanguageExt;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.LanguageExt.Tests
+{
+	public class LanguageExtMonoidValidationAssertionsTest
+	{
+		private static Validation<MSeq<int>, Seq<int>, string> SuccessResult() => "abc";
+		private static Validation<MSeq<int>, Seq<int>, string> FailResult() => Prelude.Seq1(123);
+
+		[Fact]
+		public void BeFail_with_Fail_returns_expected_result()
+		{
+			var action = () => FailResult().Should().BeFail();
+
+			action.Should().NotThrow();
+		}
+
+		[Fact]
+		public void BeFail_with_Success_returns_expected_result()
+		{
+			var action = () => SuccessResult().Should().BeFail();
+
+			action.Should().Throw<XunitException>();
+		}
+
+		[Fact]
+		public void BeFail_with_Fail_using_which_returns_expected_result()
+		{
+			var action = () => FailResult().Should().BeFail().Which.Should().BeEquivalentTo(new[] {123});
+
+			action.Should().NotThrow();
+		}
+
+		[Fact]
+		public void BeFail_with_unexpected_Fail_using_which_returns_expected_result()
+		{
+			var action = () => FailResult().Should().BeFail().Which.Should().BeEquivalentTo(new[] {456});
+
+			action.Should().Throw<XunitException>();
+		}
+
+		[Fact]
+		public void BeSuccess_with_Fail_returns_expected_result()
+		{
+			var action = () => FailResult().Should().BeSuccess();
+
+			action.Should().Throw<XunitException>();
+		}
+
+		[Fact]
+		public void BeSuccess_with_Success_returns_expected_result()
+		{
+			var action = () => SuccessResult().Should().BeSuccess();
+
+			action.Should().NotThrow();
+		}
+
+		[Fact]
+		public void BeSuccess_with_Success_using_which_returns_expected_result()
+		{
+			var action = () => SuccessResult().Should().BeSuccess().Which.Should().Be("abc");
+
+			action.Should().NotThrow();
+		}
+
+		[Fact]
+		public void BeSuccess_with_unexpected_Success_using_which_returns_expected_result()
+		{
+			var action = () => SuccessResult().Should().BeSuccess().Which.Should().Be("def");
+
+			action.Should().Throw<XunitException>();
+		}
+	}
+}

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtOptionAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtOptionAssertionsTest.cs
@@ -42,6 +42,22 @@ namespace FluentAssertions.LanguageExt.Tests
         }
 
         [Fact]
+        public void BeSome_with_expected_Some_using_which_returns_expected_result()
+        {
+            var action = () => SomeResult().Should().BeSome().Which.Should().Be(8);
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void BeSome_with_unexpected_Some_using_which_returns_expected_result()
+        {
+            var action = () => SomeResult().Should().BeSome().Which.Should().Be(4);
+
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
         public void BeNone_with_Some_returns_expected_result()
         {
             var action = () => SomeResult().Should().BeNone();

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtOptionAsyncAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtOptionAsyncAssertionsTest.cs
@@ -42,6 +42,22 @@ public class LanguageExtOptionAsyncAssertionsTest
     }
 
     [Fact]
+    public void BeSome_with_expected_Some_using_which_returns_expected_result()
+    {
+        var action = () => SomeResult().Should().BeSome().Which.Should().Be(8);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeSome_with_unexpected_Some_using_which_returns_expected_result()
+    {
+        var action = () => SomeResult().Should().BeSome().Which.Should().Be(4);
+
+        action.Should().Throw<XunitException>();
+    }
+
+    [Fact]
     public void BeNone_with_SomeAsync_returns_expected_result()
     {
         var action = () => SomeResult().Should().BeNone();

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtOptionUnsafeAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtOptionUnsafeAssertionsTest.cs
@@ -42,6 +42,22 @@ public class LanguageExtOptionUnsafeAssertionsTest
     }
 
     [Fact]
+    public void BeSome_with_expected_Some_using_which_returns_expected_result()
+    {
+        var action = () => SomeResult().Should().BeSome().Which.Should().Be(8);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeSome_with_unexpected_Some_using_which_returns_expected_result()
+    {
+        var action = () => SomeResult().Should().BeSome().Which.Should().Be(4);
+
+        action.Should().Throw<XunitException>();
+    }
+
+    [Fact]
     public void BeNone_with_SomeUnsafe_returns_expected_result()
     {
         var action = () => SomeResult().Should().BeNone();

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtTryAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtTryAssertionsTest.cs
@@ -42,6 +42,21 @@ public class LanguageExtTryAssertionsTest
         action.Should().Throw<XunitException>();
     }
 
+    [Fact]
+    public void BeSuccess_with_expected_Success_using_which_returns_expected_result()
+    {
+        var action = () => SuccessResult().Should().BeSuccess().Which.Should().Be("success");
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeSuccess_with_unexpected_Success_using_which_returns_expected_result()
+    {
+        var action = () => SuccessResult().Should().BeSuccess().Which.Should().Be("fail");
+
+        action.Should().Throw<XunitException>();
+    }
 
     [Fact]
     public void BeFail_with_Success_returns_expected_result()
@@ -57,6 +72,22 @@ public class LanguageExtTryAssertionsTest
         var action = () => FailResult().Should().BeFail();
 
         action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeFail_with_expected_Exception_returns_expected_result()
+    {
+        var action = () => FailResult().Should().BeFail().Which.Should().BeOfType<Exception>();
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeFail_with_unexpected_Exception_returns_expected_result()
+    {
+        var action = () => FailResult().Should().BeFail().Which.Should().BeOfType<ArgumentException>();
+
+        action.Should().Throw<XunitException>();
     }
 
     [Fact]

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtTryAsyncAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtTryAsyncAssertionsTest.cs
@@ -42,6 +42,22 @@ public class LanguageExtTryAsyncAssertionsTest
         action.Should().Throw<XunitException>();
     }
 
+    [Fact]
+    public void BeSuccess_with_expected_Success_using_which_returns_expected_result()
+    {
+        var action = () => SuccessResult().Should().BeSuccess().Which.Should().Be("success");
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeSuccess_with_unexpected_Success_using_which_returns_expected_result()
+    {
+        var action = () => SuccessResult().Should().BeSuccess().Which.Should().Be("fail");
+
+        action.Should().Throw<XunitException>();
+    }
+
 
     [Fact]
     public void BeFail_with_Success_returns_expected_result()
@@ -83,4 +99,19 @@ public class LanguageExtTryAsyncAssertionsTest
         action.Should().Throw<XunitException>();
     }
 
+    [Fact]
+    public void BeFail_with_expected_Exception_returns_expected_result()
+    {
+        var action = () => FailResult().Should().BeFail().Which.ToException().Should().BeOfType<Exception>();
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeFail_with_unexpected_Exception_returns_expected_result()
+    {
+        var action = () => FailResult().Should().BeFail().Which.ToException().Should().BeOfType<ArgumentException>();
+
+        action.Should().Throw<XunitException>();
+    }
 }

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtTryOptionAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtTryOptionAssertionsTest.cs
@@ -52,6 +52,22 @@ public class LanguageExtTryOptionAssertionsTest
     }
 
     [Fact]
+    public void BeSome_with_expected_Some_using_which_returns_expected_result()
+    {
+        var action = () => SomeResult().Should().BeSome().Which.Should().Be(8);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeSome_with_unexpected_Some_using_which_returns_expected_result()
+    {
+        var action = () => SomeResult().Should().BeSome().Which.Should().Be(4);
+
+        action.Should().Throw<XunitException>();
+    }
+
+    [Fact]
     public void BeNone_with_Some_returns_expected_result()
     {
         var action = () => SomeResult().Should().BeNone();
@@ -121,6 +137,22 @@ public class LanguageExtTryOptionAssertionsTest
         var action = () => FailResult().Should().BeFail();
 
         action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeFail_with_expected_Fail_returns_expected_result()
+    {
+        var action = () => FailResult().Should().BeFail().Which.Should().BeOfType<Exception>();
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeFail_with_unexpected_Fail_returns_expected_result()
+    {
+        var action = () => FailResult().Should().BeFail().Which.Should().BeOfType<ArgumentException>();
+
+        action.Should().Throw<XunitException>();
     }
 
     [Fact]

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtTryOptionAsyncAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtTryOptionAsyncAssertionsTest.cs
@@ -52,6 +52,22 @@ public class LanguageExtTryOptionAsyncAssertionsTest
     }
 
     [Fact]
+    public void BeSome_with_expected_Some_using_which_returns_expected_result()
+    {
+        var action = () => SomeResult().Should().BeSome().Which.Should().Be(8);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeSome_with_unexpected_Some_using_which_returns_expected_result()
+    {
+        var action = () => SomeResult().Should().BeSome().Which.Should().Be(4);
+
+        action.Should().Throw<XunitException>();
+    }
+
+    [Fact]
     public void BeNone_with_Some_returns_expected_result()
     {
         var action = () => SomeResult().Should().BeNone();
@@ -121,6 +137,22 @@ public class LanguageExtTryOptionAsyncAssertionsTest
         var action = () => FailResult().Should().BeFail();
 
         action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeFail_with_expected_Fail_returns_expected_result()
+    {
+        var action = () => FailResult().Should().BeFail().Which.Should().BeOfType<Exception>();
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeFail_with_unexpected_Fail_returns_expected_result()
+    {
+        var action = () => FailResult().Should().BeFail().Which.Should().BeOfType<ArgumentException>();
+
+        action.Should().Throw<XunitException>();
     }
 
     [Fact]

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtValidationAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtValidationAssertionsTest.cs
@@ -26,6 +26,22 @@ public class LanguageExtValidationAssertionsTest
     }
 
     [Fact]
+    public void BeFail_with_Fail_using_which_returns_expected_result()
+    {
+        var action = () => FailResult().Should().BeFail().Which.Should().Be(123);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeFail_with_unexpected_Fail_using_which_returns_expected_result()
+    {
+        var action = () => FailResult().Should().BeFail().Which.Should().Be(456);
+
+        action.Should().Throw<XunitException>();
+    }
+
+    [Fact]
     public void BeSuccess_with_Fail_returns_expected_result()
     {
         var action = () => FailResult().Should().BeSuccess();
@@ -39,5 +55,21 @@ public class LanguageExtValidationAssertionsTest
         var action = () => SuccessResult().Should().BeSuccess();
 
         action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeSuccess_with_Success_using_which_returns_expected_result()
+    {
+        var action = () => SuccessResult().Should().BeSuccess().Which.Should().Be("abc");
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BeSuccess_with_unexpected_Success_using_which_returns_expected_result()
+    {
+        var action = () => SuccessResult().Should().BeSuccess().Which.Should().Be("def");
+
+        action.Should().Throw<XunitException>();
     }
 }

--- a/src/FluentAssertions.LanguageExt/LanguageExtEitherAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtEitherAssertions.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.LanguageExt
 
         protected override string Identifier => "either";
 
-        public AndConstraint<LanguageExtEitherAssertions<TL, TR>> BeLeft(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtEitherAssertions<TL, TR>, TL> BeLeft(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -22,7 +22,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsLeft)
                 .FailWith("but found to be Right.");
 
-            return new AndConstraint<LanguageExtEitherAssertions<TL, TR>>(this);
+            return new AndWhichConstraint<LanguageExtEitherAssertions<TL, TR>, TL>(this, Subject.LeftAsEnumerable());
         }
 
         public AndConstraint<LanguageExtEitherAssertions<TL, TR>> BeLeft(Action<TL> action, string because = "", params object[] becauseArgs)
@@ -33,7 +33,7 @@ namespace FluentAssertions.LanguageExt
             return new AndConstraint<LanguageExtEitherAssertions<TL, TR>>(this);
         }
 
-        public AndConstraint<LanguageExtEitherAssertions<TL, TR>> BeRight(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtEitherAssertions<TL, TR>, TR> BeRight(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -42,7 +42,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsRight)
                 .FailWith("but found to be Left.");
 
-            return new AndConstraint<LanguageExtEitherAssertions<TL, TR>>(this);
+            return new AndWhichConstraint<LanguageExtEitherAssertions<TL, TR>, TR>(this, Subject.RightAsEnumerable());
         }
 
         public AndConstraint<LanguageExtEitherAssertions<TL, TR>> BeRight(Action<TR> action, string because = "", params object[] becauseArgs)

--- a/src/FluentAssertions.LanguageExt/LanguageExtEitherAsyncAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtEitherAsyncAssertions.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions.LanguageExt
 
         protected override string Identifier => "eitherasync";
 
-        public AndConstraint<LanguageExtEitherAsyncAssertions<TL, TR>> BeLeft(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtEitherAsyncAssertions<TL, TR>, TL> BeLeft(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -23,7 +23,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => Run(() => subject.IsLeft))
                 .FailWith("but found to be Right.");
 
-            return new AndConstraint<LanguageExtEitherAsyncAssertions<TL, TR>>(this);
+            return new AndWhichConstraint<LanguageExtEitherAsyncAssertions<TL, TR>, TL>(this, Run(() => Subject.LeftAsEnumerable()));
         }
 
         public AndConstraint<LanguageExtEitherAsyncAssertions<TL, TR>> BeLeft(Action<TL> action, string because = "", params object[] becauseArgs)
@@ -34,7 +34,7 @@ namespace FluentAssertions.LanguageExt
             return new AndConstraint<LanguageExtEitherAsyncAssertions<TL, TR>>(this);
         }
 
-        public AndConstraint<LanguageExtEitherAsyncAssertions<TL, TR>> BeRight(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtEitherAsyncAssertions<TL, TR>, TR> BeRight(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -43,7 +43,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => Run(() => subject.IsRight))
                 .FailWith("but found to be Left.");
 
-            return new AndConstraint<LanguageExtEitherAsyncAssertions<TL, TR>>(this);
+            return new AndWhichConstraint<LanguageExtEitherAsyncAssertions<TL, TR>, TR>(this, Run(() => Subject.RightAsEnumerable()));
         }
 
         public AndConstraint<LanguageExtEitherAsyncAssertions<TL, TR>> BeRight(Action<TR> action, string because = "", params object[] becauseArgs)

--- a/src/FluentAssertions.LanguageExt/LanguageExtEitherUnsafeAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtEitherUnsafeAssertions.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.LanguageExt
 
         protected override string Identifier => "eitherunsafe";
 
-        public AndConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>> BeLeft(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>, TL> BeLeft(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -22,7 +22,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsLeft)
                 .FailWith("but found to be Right.");
 
-            return new AndConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>>(this);
+            return new AndWhichConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>, TL>(this, Subject.LeftAsEnumerable());
         }
 
         public AndConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>> BeLeft(Action<TL> action, string because = "", params object[] becauseArgs)
@@ -33,7 +33,7 @@ namespace FluentAssertions.LanguageExt
             return new AndConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>>(this);
         }
 
-        public AndConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>> BeRight(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>, TR> BeRight(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -42,7 +42,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsRight)
                 .FailWith("but found to be Left.");
 
-            return new AndConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>>(this);
+            return new AndWhichConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>, TR>(this, Subject.RightAsEnumerable());
         }
 
         public AndConstraint<LanguageExtEitherUnsafeAssertions<TL, TR>> BeRight(Action<TR> action, string because = "", params object[] becauseArgs)

--- a/src/FluentAssertions.LanguageExt/LanguageExtMonoidValidationAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtMonoidValidationAssertions.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.LanguageExt
 
         protected override string Identifier => "monoidalvalidation";
 
-        public AndConstraint<LanguageExtMonoidValidationAssertions<TMonoidFail, TFail, TSuccess>> BeFail(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtMonoidValidationAssertions<TMonoidFail, TFail, TSuccess>, TFail> BeFail(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -22,10 +22,10 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsFail)
                 .FailWith("but found to be {0}.", Subject);
 
-            return new AndConstraint<LanguageExtMonoidValidationAssertions<TMonoidFail, TFail, TSuccess>>(this);
+            return new AndWhichConstraint<LanguageExtMonoidValidationAssertions<TMonoidFail, TFail, TSuccess>, TFail>(this, Subject.FailAsEnumerable());
         }
 
-        public AndConstraint<LanguageExtMonoidValidationAssertions<TMonoidFail, TFail, TSuccess>> BeSuccess(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtMonoidValidationAssertions<TMonoidFail, TFail, TSuccess>, TSuccess> BeSuccess(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -34,7 +34,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsSuccess)
                 .FailWith("but found to be {0}.", Subject);
 
-            return new AndConstraint<LanguageExtMonoidValidationAssertions<TMonoidFail, TFail, TSuccess>>(this);
+            return new AndWhichConstraint<LanguageExtMonoidValidationAssertions<TMonoidFail, TFail, TSuccess>, TSuccess>(this, Subject.SuccessAsEnumerable());
         }
     }
 }

--- a/src/FluentAssertions.LanguageExt/LanguageExtOptionAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtOptionAssertions.cs
@@ -25,7 +25,7 @@ namespace FluentAssertions.LanguageExt
             return new AndConstraint<LanguageExtOptionAssertions<T>>(this);
         }
 
-        public AndConstraint<LanguageExtOptionAssertions<T>> BeSome(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtOptionAssertions<T>, T> BeSome(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -34,7 +34,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsSome)
                 .FailWith("but found to be None.");
 
-            return new AndConstraint<LanguageExtOptionAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtOptionAssertions<T>, T>(this, Subject);
         }
 
         public AndConstraint<LanguageExtOptionAssertions<T>> BeSome(Action<T> action, string because = "", params object[] becauseArgs)

--- a/src/FluentAssertions.LanguageExt/LanguageExtOptionAsyncAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtOptionAsyncAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using LanguageExt;
@@ -26,7 +26,7 @@ namespace FluentAssertions.LanguageExt
             return new AndConstraint<LanguageExtOptionAsyncAssertions<T>>(this);
         }
 
-        public AndConstraint<LanguageExtOptionAsyncAssertions<T>> BeSome(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtOptionAsyncAssertions<T>, T> BeSome(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -35,7 +35,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => Run(() => subject.IsSome))
                 .FailWith("but found to be None.");
 
-            return new AndConstraint<LanguageExtOptionAsyncAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtOptionAsyncAssertions<T>, T>(this, Run(() => Subject.AsEnumerable()));
         }
 
         public AndConstraint<LanguageExtOptionAsyncAssertions<T>> BeSome(Action<T> action, string because = "", params object[] becauseArgs)

--- a/src/FluentAssertions.LanguageExt/LanguageExtOptionUnsafeAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtOptionUnsafeAssertions.cs
@@ -26,7 +26,7 @@ namespace FluentAssertions.LanguageExt
             return new AndConstraint<LanguageExtOptionUnsafeAssertions<T>>(this);
         }
 
-        public AndConstraint<LanguageExtOptionUnsafeAssertions<T>> BeSome(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtOptionUnsafeAssertions<T>, T> BeSome(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -35,7 +35,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsSome)
                 .FailWith("but found to be None.");
 
-            return new AndConstraint<LanguageExtOptionUnsafeAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtOptionUnsafeAssertions<T>, T>(this, Subject);
         }
 
         public AndConstraint<LanguageExtOptionUnsafeAssertions<T>> BeSome(Action<T> action, string because = "", params object[] becauseArgs)

--- a/src/FluentAssertions.LanguageExt/LanguageExtTryAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtTryAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using LanguageExt;
@@ -13,7 +13,7 @@ namespace FluentAssertions.LanguageExt
 
         protected override string Identifier => "try";
 
-        public AndConstraint<LanguageExtTryAssertions<T>> BeFail(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtTryAssertions<T>, Exception> BeFail(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -22,13 +22,11 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsFail())
                 .FailWith("but found to be not.");
 
-            return new AndConstraint<LanguageExtTryAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtTryAssertions<T>, Exception>(this, Subject.ToEither().LeftAsEnumerable());
         }
 
-        public AndConstraint<LanguageExtTryAssertions<T>> BeSuccess(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtTryAssertions<T>, T> BeSuccess(string because = "", params object[] becauseArgs)
         {
-        
-
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:try} to be Success{reason}, ")
@@ -36,7 +34,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsSucc())
                 .FailWith("but found to be not.");
 
-            return new AndConstraint<LanguageExtTryAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtTryAssertions<T>, T>(this, Subject.AsEnumerable());
         }
 
         public AndConstraint<LanguageExtTryAssertions<T>> BeSuccess(Action<T> action, string because = "", params object[] becauseArgs)

--- a/src/FluentAssertions.LanguageExt/LanguageExtTryAsyncAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtTryAsyncAssertions.cs
@@ -2,6 +2,7 @@
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using LanguageExt;
+using LanguageExt.Common;
 using static Nito.AsyncEx.AsyncContext;
 
 namespace FluentAssertions.LanguageExt
@@ -14,7 +15,7 @@ namespace FluentAssertions.LanguageExt
 
         protected override string Identifier => "tryasync";
 
-        public AndConstraint<LanguageExtTryAsyncAssertions<T>> BeFail(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtTryAsyncAssertions<T>, Error> BeFail(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -23,10 +24,10 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => Run(subject.IsFail))
                 .FailWith("but found to be not.");
 
-            return new AndConstraint<LanguageExtTryAsyncAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtTryAsyncAssertions<T>, Error>(this, Run(() => Subject.ToEither().LeftAsEnumerable()));
         }
 
-        public AndConstraint<LanguageExtTryAsyncAssertions<T>> BeSuccess(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtTryAsyncAssertions<T>, T> BeSuccess(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -35,7 +36,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => Run(subject.IsSucc))
                 .FailWith("but found to be not.");
 
-            return new AndConstraint<LanguageExtTryAsyncAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtTryAsyncAssertions<T>, T>(this, Run(() => Subject.AsEnumerable()));
         }
 
         public AndConstraint<LanguageExtTryAsyncAssertions<T>> BeSuccess(Action<T> action, string because = "", params object[] becauseArgs)

--- a/src/FluentAssertions.LanguageExt/LanguageExtTryOptionAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtTryOptionAssertions.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.LanguageExt
 
         protected override string Identifier => "tryoption";
 
-        public AndConstraint<LanguageExtTryOptionAssertions<T>> BeFail(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtTryOptionAssertions<T>, Exception> BeFail(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -22,10 +22,10 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsFail())
                 .FailWith("but found to be not.");
 
-            return new AndConstraint<LanguageExtTryOptionAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtTryOptionAssertions<T>, Exception>(this, Subject.ToEither().LeftAsEnumerable());
         }
 
-        public AndConstraint<LanguageExtTryOptionAssertions<T>> BeSome(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtTryOptionAssertions<T>, T> BeSome(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -34,7 +34,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsSome())
                 .FailWith("but found to be not.");
 
-            return new AndConstraint<LanguageExtTryOptionAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtTryOptionAssertions<T>, T>(this, Subject.AsEnumerable());
         }
 
         public AndConstraint<LanguageExtTryOptionAssertions<T>> BeSome(Action<T> action, string because = "", params object[] becauseArgs)

--- a/src/FluentAssertions.LanguageExt/LanguageExtTryOptionAsyncAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtTryOptionAsyncAssertions.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions.LanguageExt
 
         protected override string Identifier => "tryoptionasync";
 
-        public AndConstraint<LanguageExtTryOptionAsyncAssertions<T>> BeFail(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtTryOptionAsyncAssertions<T>, Exception> BeFail(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -23,10 +23,10 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => Run(subject.IsFail))
                 .FailWith("but found to be not.");
 
-            return new AndConstraint<LanguageExtTryOptionAsyncAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtTryOptionAsyncAssertions<T>, Exception>(this, Run(() => Subject.ToEither()).LeftAsEnumerable());
         }
 
-        public AndConstraint<LanguageExtTryOptionAsyncAssertions<T>> BeSome(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtTryOptionAsyncAssertions<T>, T> BeSome(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -35,7 +35,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => Run(subject.IsSome))
                 .FailWith("but found to be not.");
 
-            return new AndConstraint<LanguageExtTryOptionAsyncAssertions<T>>(this);
+            return new AndWhichConstraint<LanguageExtTryOptionAsyncAssertions<T>, T>(this, Run(() => Subject.AsEnumerable()));
         }
 
         public AndConstraint<LanguageExtTryOptionAsyncAssertions<T>> BeSome(Action<T> action, string because = "", params object[] becauseArgs)

--- a/src/FluentAssertions.LanguageExt/LanguageExtValidationAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtValidationAssertions.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.LanguageExt
 
         protected override string Identifier => "validation";
 
-        public AndConstraint<LanguageExtValidationAssertions<TFail, TSuccess>> BeFail(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtValidationAssertions<TFail, TSuccess>, TFail> BeFail(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -22,10 +22,10 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsFail)
                 .FailWith("but found to be {0}.", Subject);
 
-            return new AndConstraint<LanguageExtValidationAssertions<TFail, TSuccess>>(this);
+            return new AndWhichConstraint<LanguageExtValidationAssertions<TFail, TSuccess>, TFail>(this, Subject.FailAsEnumerable());
         }
 
-        public AndConstraint<LanguageExtValidationAssertions<TFail, TSuccess>> BeSuccess(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtValidationAssertions<TFail, TSuccess>, TSuccess> BeSuccess(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -34,7 +34,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsSuccess)
                 .FailWith("but found to be {0}.", Subject);
 
-            return new AndConstraint<LanguageExtValidationAssertions<TFail, TSuccess>>(this);
+            return new AndWhichConstraint<LanguageExtValidationAssertions<TFail, TSuccess>, TSuccess>(this, Subject.SuccessAsEnumerable());
         }
 
         public AndConstraint<LanguageExtValidationAssertions<TFail, TSuccess>> BeSuccess(Action<TSuccess> action, string because = "", params object[] becauseArgs)


### PR DESCRIPTION
This PR enables the FluentAsserts `.Which` sub-assertion helper when asserting on a value-containing state of a monad (BeSome, BeLeft, etc).

One odd thing that I found when implementing this is that `LanguageExtTryAssertions.BeFail` returns an `Exception` type when converted to an `Either` in order to grab the failure message. However, `LanguageExtTryAsyncAssertions.BeFail` returns an `Error` type. I've left this difference as is, but it may be confusing for an end user. I'm not exactly sure why LanguageExt is returning a different type in this case. We can either leave it, make both use `Exception`, or make both use `Error`. Not sure what the best choice is, so it is up to you.

Resolves #2 