### PR TITLE
BREAKING: "BeFail().Which" extension now correctly returns enumerable for Validation types

### DIFF
--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtValidationAssertionsTest.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtValidationAssertionsTest.cs
@@ -28,7 +28,7 @@ public class LanguageExtValidationAssertionsTest
     [Fact]
     public void BeFail_with_Fail_using_which_returns_expected_result()
     {
-        var action = () => FailResult().Should().BeFail().Which.Should().Be(123);
+        var action = () => FailResult().Should().BeFail().Which.Should().BeEquivalentTo(new[] { 123 });
 
         action.Should().NotThrow();
     }
@@ -36,7 +36,7 @@ public class LanguageExtValidationAssertionsTest
     [Fact]
     public void BeFail_with_unexpected_Fail_using_which_returns_expected_result()
     {
-        var action = () => FailResult().Should().BeFail().Which.Should().Be(456);
+        var action = () => FailResult().Should().BeFail().Which.Should().BeEquivalentTo(new[] { 456 });
 
         action.Should().Throw<XunitException>();
     }

--- a/src/FluentAssertions.LanguageExt/LanguageExtValidationAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtValidationAssertions.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.LanguageExt
 
         protected override string Identifier => "validation";
 
-        public AndWhichConstraint<LanguageExtValidationAssertions<TFail, TSuccess>, TFail> BeFail(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<LanguageExtValidationAssertions<TFail, TSuccess>, Seq<TFail>> BeFail(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -22,7 +22,7 @@ namespace FluentAssertions.LanguageExt
                 .ForCondition(subject => subject.IsFail)
                 .FailWith("but found to be {0}.", Subject);
 
-            return new AndWhichConstraint<LanguageExtValidationAssertions<TFail, TSuccess>, TFail>(this, Subject.FailAsEnumerable());
+            return new AndWhichConstraint<LanguageExtValidationAssertions<TFail, TSuccess>, Seq<TFail>>(this, Subject.FailAsEnumerable());
         }
 
         public AndWhichConstraint<LanguageExtValidationAssertions<TFail, TSuccess>, TSuccess> BeSuccess(string because = "", params object[] becauseArgs)


### PR DESCRIPTION
This PR modifies the return signature of the `LanguageExtValidationAssertions.BeFail()` method to correctly return a collection of failures from the `Validation` type.

This resolves #4