### PR TITLE
feat: Added support for asserting on Fin<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,30 @@ Special thanks to @sparerd.
 - `BeNone()`
 - `BeNoneOrFail()`
 - `Be(expected)`
+
+### Fin
+
+#### Methods
+- `BeSuccess()`
+- `BeSuccess(action)`
+- `BeFail()`
+- `BeBottom()`
+- `Be(expected)`
+
+#### Example Usage
+```c#
+using FluentAssertions;
+using FluentAssertions.LanguageExt;
+
+... 
+Fin<int> successFin = Prelude.FinSucc(8);
+Fin<int> failedFin = Prelude.FinFail<int>("Error message");
+
+successFin.Should().BeSuccess();
+successFin.Should().BeSuccess(v => v.Should().Be(8));
+successFin.Should().BeSuccess().Which.Should().Be(8);
+successFin.Should().Be(8);
+
+failedFin.Should().BeFail();
+failedFin.Should().BeFail().Which.Message.Should().Be("Error message");
+```

--- a/src/FluentAssertions.LanguageExt.Tests/LanguageExtFinAssertionsTests.cs
+++ b/src/FluentAssertions.LanguageExt.Tests/LanguageExtFinAssertionsTests.cs
@@ -1,0 +1,152 @@
+﻿using LanguageExt;
+using Xunit;
+using Xunit.Sdk;
+using static LanguageExt.Prelude;
+
+namespace FluentAssertions.LanguageExt.Tests
+{
+    public class LanguageExtFinAssertionsTests
+    {
+        private static Fin<int> SuccessFin => FinSucc(1);
+        private static Fin<int> FailureFin => FinFail<int>("Error msg");
+        private static Fin<int> BottomFin => FinFail<int>(default);
+
+        [Fact]
+        public void Be_with_expected_Success_returns_expected_result()
+        {
+            var action = () => SuccessFin.Should().Be(1);
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Be_with_unexpected_Success_returns_expected_result()
+        {
+            var action = () => SuccessFin.Should().Be(999);
+
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Be_with_Fail_returns_expected_result()
+        {
+            var action = () => FailureFin.Should().Be(1);
+
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void BeSuccess_with_Success_returns_expected_result()
+        {
+            var action = () => SuccessFin.Should().BeSuccess();
+            
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void BeSuccess_with_Fail_returns_expected_result()
+        {
+            var action = () => FailureFin.Should().BeSuccess();
+
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void BeSuccess_with_Bottom_returns_expected_result()
+        {
+            var action = () => BottomFin.Should().BeSuccess();
+
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void BeSuccess_with_expected_Success_returns_expected_result()
+        {
+            var action = () => SuccessFin.Should().BeSuccess(s => s.Should().Be(1));
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void BeSuccess_with_unexpected_Success_returns_expected_result()
+        {
+            var action = () => SuccessFin.Should().BeSuccess(s => s.Should().Be(999));
+
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void BeSuccess_with_expected_Success_using_which_returns_expected_result()
+        {
+            var action = () => SuccessFin.Should().BeSuccess().Which.Should().Be(1);
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void BeSuccess_with_unexpected_Success_using_which_returns_expected_result()
+        {
+            var action = () => SuccessFin.Should().BeSuccess().Which.Should().Be(999);
+
+            action.Should().Throw<XunitException>();
+        }
+
+
+
+        [Fact]
+        public void BeFail_with_Success_returns_expected_result()
+        {
+            var action = () => SuccessFin.Should().BeFail();
+
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void BeFail_with_Error_returns_expected_result()
+        {
+            var action = () => FailureFin.Should().BeFail();
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void BeFail_with_expected_Error_returns_expected_result()
+        {
+            var action = () => FailureFin.Should().BeFail().Which.Message.Should().Be("Error msg");
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void BeFail_with_unexpected_Error_returns_expected_result()
+        {
+            var action = () => FailureFin.Should().BeFail().Which.Message.Should().Be("Not correct msg");
+
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void BeBottom_with_Bottom_returns_expected_result()
+        {
+            var action = () => BottomFin.Should().BeBottom();
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void BeBottom_with_Success_returns_expected_result()
+        {
+            var action = () => SuccessFin.Should().BeBottom();
+
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void BeBottom_with_Failure_returns_expected_result()
+        {
+            var action = () => FailureFin.Should().BeBottom();
+
+            action.Should().Throw<XunitException>();
+        }
+    }
+}

--- a/src/FluentAssertions.LanguageExt/FunctionalAssertionExtensions.cs
+++ b/src/FluentAssertions.LanguageExt/FunctionalAssertionExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace FluentAssertions.LanguageExt
+{
+    internal static class FunctionalAssertionExtensions
+    {
+        internal static AndWhichConstraint<TParent, TContinuation> ContinueWhich<TParent, TContinuation>(
+            TParent originalConstraint, TContinuation continuationValue) => new(originalConstraint, continuationValue);
+
+        internal static AndConstraint<TParent> ContinueAnd<TParent>(TParent originalConstraint) => new(originalConstraint);
+    }
+}

--- a/src/FluentAssertions.LanguageExt/LanguageExtAssertionsExtensions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtAssertionsExtensions.cs
@@ -38,5 +38,7 @@ namespace FluentAssertions.LanguageExt
         public static LanguageExtTryOptionAsyncAssertions<T> Should<T>(this TryOptionAsync<T> instance) => new(instance);
 
         public static LanguageExtTryOptionAssertions<T> Should<T>(this TryOption<T> instance) => new(instance);
+
+        public static LanguageExtFinAssertions<T> Should<T>(this Fin<T> instance) => new(instance);
     }
 }

--- a/src/FluentAssertions.LanguageExt/LanguageExtFinAssertions.cs
+++ b/src/FluentAssertions.LanguageExt/LanguageExtFinAssertions.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using LanguageExt;
+using LanguageExt.Common;
+using static FluentAssertions.LanguageExt.FunctionalAssertionExtensions;
+
+namespace FluentAssertions.LanguageExt
+{
+    public class LanguageExtFinAssertions<T> : ReferenceTypeAssertions<Fin<T>, LanguageExtFinAssertions<T>>
+    {
+        public LanguageExtFinAssertions(Fin<T> subject) : base(subject)
+        {
+        }
+
+        protected override string Identifier => "fin";
+
+        public AndConstraint<LanguageExtFinAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) => 
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:fin} to be {0}{reason}, ", expected)
+                .Given(() => Subject)
+                .ForCondition(subject => subject.IsSucc)
+                .FailWith("but found to be not.")
+                .Then
+                .ForCondition(subject => subject == expected)
+                .FailWith("but found to be {0}.", (T)Subject)
+                .Apply(_ => ContinueAnd(this));
+
+        public AndWhichConstraint<LanguageExtFinAssertions<T>, T> BeSuccess(string because = "", params object[] becauseArgs) =>
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:fin} to be Success{reason}, ")
+                .Given(() => Subject)
+                .ForCondition(subject => subject.IsSucc)
+                .FailWith("but found to be not.")
+                .Apply(_ => ContinueWhich(this, (T)Subject));
+
+        public AndConstraint<LanguageExtFinAssertions<T>> BeSuccess(Action<T> action, string because = "", params object[] becauseArgs) =>
+            BeSuccess(because, becauseArgs)
+                .Apply(a => a.And.Subject.IfSucc(action))
+                .Apply(_ => ContinueAnd(this));
+
+        public AndWhichConstraint<LanguageExtFinAssertions<T>, Error> BeFail(string because = "", params object[] becauseArgs) =>
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:fin} to be Fail{reason}, ")
+                .Given(() => Subject)
+                .ForCondition(subject => subject.IsFail)
+                .FailWith("but found to be not.")
+                .Apply(_ => ContinueWhich(this, Subject.Match(_ => default, error => error)));
+
+        public AndConstraint<LanguageExtFinAssertions<T>> BeBottom(string because = "", params object[] becauseArgs) =>
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:fin} to be Bottom{reason}, ")
+                .Given(() => Subject)
+                .ForCondition(subject => subject.IsBottom)
+                .FailWith("but found to be not.")
+                .Apply(_ => ContinueAnd(this));
+    }
+}


### PR DESCRIPTION
This PR adds support for asserting on the `Fin<T>` monad. This mostly mirrors the support for `Either<L, R>` since `Fin<T>` is effectively a `Either<Error, T>`.

I've also added some static functions that make it a little nicer to create and apply continuation types, which allows the assertion methods to be expressions. Let me know if the style is ok.